### PR TITLE
Publish outboxer to GitHub Container Registry

### DIFF
--- a/.github/workflows/outboxer.yml
+++ b/.github/workflows/outboxer.yml
@@ -42,3 +42,30 @@ jobs:
       - name: Execute test
         working-directory: ./integration-test
         run: npm run test
+
+# Authentication to GitHub container registry is only possible with an personal access token (PAT)
+# The publish job requires a secret named `GHCR_PAT` which must contain a PAT with the `read:packages`
+# and `write:packages` scope.
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: [test]
+    if: github.ref == 'refs/heads/ghcr-test'
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: outboxer-artifact
+      - name: Load docker image from artifact
+        run: docker load -i ./outboxer-artifact/outboxer.tar
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GHCR_PAT }}
+      - name: Push to GitHub container registry
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/outboxer-postgres2rabbitmq
+          docker tag outboxer-postgres2rabbitmq:latest $IMAGE_ID:latest
+          docker push $IMAGE_ID:latest

--- a/.github/workflows/outboxer.yml
+++ b/.github/workflows/outboxer.yml
@@ -50,7 +50,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     needs: [test]
-    if: github.ref == 'refs/heads/ghcr-test'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v1


### PR DESCRIPTION
To be able to use outboxer in the ODS, I propose to publish a docker image to the new [GitHub Container Registry](https://docs.github.com/en/packages/guides/about-github-container-registry). The main advantage over the old GitHub Packages Docker registry is that public container images can be accessed anonymously (e.g. without authentication). And the GitHub Container Registry will supersede the GitHub Packages Docker registry one day (see [here](https://docs.github.com/en/packages/guides/migrating-to-github-container-registry-for-docker-images#key-differences-between-github-container-registry-and-the-docker-package-registry) and [here](https://github.community/t/packages-this-service-is-deprecated/136831https://github.community/t/packages-this-service-is-deprecated/136831/3)).

GitHub Container Registry does require a personal access token (PAT) and does not work with the default GitHub secret `GITHUB_TOKEN`. So before merging this, a PAT must be created and added to the repository secret with the name `GHCR_PAT`. The PAT must have the scopes `read:packages` and `write:packages`. Currently, there is [a bug](https://github.community/t/how-to-create-a-pat-with-write-packages-and-without-repo-permissions/149416) in the PAT creating page, that always adds the not needed `repo` scope and does not allow to remove it. But the `repo` scope can be removed in the edit screen after creating the PAT.

Currently, every commit to the main branch will get published as a new docker image, so we can iterate faster while fixing the last bugs. Once we use the outboxer in the ODS we should, of course, add proper versioning.

Any feedback or concern about this process is highly appreciated.