### PR TITLE
Make all amqp messages persistent

### DIFF
--- a/.github/workflows/outboxer.yml
+++ b/.github/workflows/outboxer.yml
@@ -50,7 +50,7 @@ jobs:
     name: Publish
     runs-on: ubuntu-latest
     needs: [test]
-    if: github.ref == 'refs/heads/main'
+    if: github.repository == 'jvalue/outboxer-postgres2rabbitmq' && github.ref == 'refs/heads/main'
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v1

--- a/src/main/java/org/jvalue/outboxer/AmqpPublisher.java
+++ b/src/main/java/org/jvalue/outboxer/AmqpPublisher.java
@@ -9,6 +9,7 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.springframework.amqp.AmqpException;
 import org.springframework.amqp.core.AmqpTemplate;
 import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.MessageDeliveryMode;
 import org.springframework.amqp.core.MessageProperties;
 import org.springframework.amqp.rabbit.connection.CachingConnectionFactory;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -96,6 +97,8 @@ public class AmqpPublisher implements DebeziumEngine.ChangeConsumer<SourceRecord
     messageProps.setContentType(MessageProperties.CONTENT_TYPE_JSON);
     messageProps.setContentEncoding(StandardCharsets.UTF_8.name());
     messageProps.setMessageId(eventId);
+    // Persist message so it does survive RabbitMQ restarts
+    messageProps.setDeliveryMode(MessageDeliveryMode.PERSISTENT);
 
     return new Message(payload.getBytes(StandardCharsets.UTF_8), messageProps);
   }


### PR DESCRIPTION
This ensures that messages in queues do survive RabbitMQ restarts.